### PR TITLE
Example: Add a plugin to override buffs position

### DIFF
--- a/Orbit_CooldownManager_BuffsOverride/CooldownManagerBuffsOverride.lua
+++ b/Orbit_CooldownManager_BuffsOverride/CooldownManagerBuffsOverride.lua
@@ -1,0 +1,72 @@
+---@type Orbit
+local Orbit = Orbit
+local OrbitEngine = Orbit.Engine
+local Constants = Orbit.Constants
+local CooldownUtils = OrbitEngine.CooldownUtils
+
+local CDM = Orbit:GetPlugin("Orbit_CooldownViewer")
+if not CDM then return end
+
+local VIEWER_MAP = CDM.viewerMap
+local BUFFICON_INDEX = Constants.Cooldown.SystemIndex.BuffIcon
+
+local overridenCooldowns = {
+    -- Blade Flurry
+    [11873] = {
+        point = "BOTTOMRIGHT",
+        relativeTo = "OrbitPlayerResources",
+        relativePoint = "TOPRIGHT",
+        offsetX = 0,
+        offsetY = 2,
+    },
+    -- Roll the Bones
+    [42743] = {
+        point = "BOTTOMLEFT",
+        relativeTo = "OrbitPlayerResources",
+        relativePoint = "TOPLEFT",
+        offsetX = 0,
+        offsetY = 2,
+    },
+}
+
+local original_CDM_ProcessChildren = CDM.ProcessChildren;
+function CDM:ProcessChildren(...)
+    original_CDM_ProcessChildren(self, ...)
+
+    local anchor = ...;
+    if not anchor or anchor.systemIndex ~= BUFFICON_INDEX then return end
+    local entry = VIEWER_MAP[anchor.systemIndex]
+    local blizzFrame = entry and entry.viewer
+    if not blizzFrame then return end
+
+    local activeChildren = {}
+
+    for i, child in ipairs({ blizzFrame:GetChildren() }) do
+        if child.layoutIndex then
+            if child:IsShown() then
+                table.insert(activeChildren, child)
+            end
+        end
+    end
+
+    table.sort(activeChildren, function(a, b) return (a.layoutIndex or 0) < (b.layoutIndex or 0) end)
+
+    if Orbit.Skin.Icons and #activeChildren > 0 then
+        local hGrowth = CDM:GetHorizontalGrowth(anchor) or nil
+        local vGrowth = CDM:GetGrowthDirection(anchor)
+        local skinSettings = CooldownUtils:BuildSkinSettings(CDM, anchor.systemIndex, { verticalGrowth = vGrowth, horizontalGrowth = hGrowth })
+
+        local activeChildrenWithoutOverride = {}
+        for _, child in ipairs(activeChildren) do
+            if not (overridenCooldowns and overridenCooldowns[child:GetCooldownID()]) then
+                table.insert(activeChildrenWithoutOverride, child)
+            else
+                local cd = overridenCooldowns[child:GetCooldownID()]
+                child:ClearAllPoints()
+                child:SetPoint(cd.point, cd.relativeTo, cd.relativePoint, cd.offsetX, cd.offsetY)
+            end
+        end
+
+        Orbit.Skin.Icons:ApplyManualLayout(blizzFrame, activeChildrenWithoutOverride, skinSettings)
+    end
+end

--- a/Orbit_CooldownManager_BuffsOverride/Orbit_CooldownManager_BuffsOverride.toc
+++ b/Orbit_CooldownManager_BuffsOverride/Orbit_CooldownManager_BuffsOverride.toc
@@ -1,0 +1,15 @@
+## Interface: 120001, 120000
+## Title: Cooldown Manager Buffs Override
+## Notes: Override Orbit CMD Buffs position
+## Author: MoONSHO7 / M7
+## Version: @project-version@
+## Dependencies: Orbit
+## DefaultState: enabled
+## Group: Orbit
+## Category: Orbit UI
+## IconTexture: Interface\AddOns\Orbit\Core\assets\Orbit.png
+
+## X-License: All Rights Reserved
+## X-Part-Of: Orbit
+
+CooldownManagerBuffsOverride.lua


### PR DESCRIPTION
Hi,

Here is an example plugin on how to override some buffs position to wherever you want.

<img width="374" height="155" alt="image" src="https://github.com/user-attachments/assets/2f030378-6ed1-49e2-86f4-e143a6aebce6" />

Both icons from left and right are overridden and only stays there and do not impact the other non-overridden buffs dynamic positioning.

Please feel free to close this PR when you want.