### PR TITLE
bugfixes

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -8,7 +8,7 @@ call_parentheses = "Always"
 syntax = "Lua51"
 
 # Readability & Git Performance
-collapse_simple_statement = "Never"
+collapse_simple_statement = "FunctionOnly"
 
 [sort_requires]
 enabled = false

--- a/Orbit/Core/Engine/Frame/Factory.lua
+++ b/Orbit/Core/Engine/Frame/Factory.lua
@@ -127,7 +127,7 @@ function FrameFactory:Create(name, plugin, opts)
         end
 
         -- Handle Bar Inset (use calculated pixelSize from Skin)
-        local pixelSize = self.borderPixelSize or 1
+        local pixelSize = self.borderPixelSize or Engine.Pixel:Multiple(1, self:GetEffectiveScale() or 1)
         local bar = self.orbitBar or self.Bar
         if bar then
             bar:ClearAllPoints()

--- a/Orbit/Core/Engine/Pixel.lua
+++ b/Orbit/Core/Engine/Pixel.lua
@@ -56,6 +56,16 @@ function Pixel:Snap(value, scale)
     return math.floor(value / step + 0.5) * step
 end
 
+--- Convert a Physical Pixel count to Logical Units
+-- @param count number: Physical pixels (e.g. BorderSize=2 means 2 screen pixels)
+-- @param scale number: (Optional) Frame Effective Scale. Defaults to 1.
+-- @return number: Logical size that renders as exactly `count` physical pixels
+function Pixel:Multiple(count, scale)
+    local frameScale = scale or 1
+    if frameScale < 0.01 then frameScale = 1 end
+    return (count or 0) * SCREEN_SCALE / frameScale
+end
+
 -- [ ENFORCEMENT ]-----------------------------------------------------------------------------------
 
 --- Enforce pixel-perfect sizing on a frame

--- a/Orbit/Core/Engine/UnitButton/UnitButtonCore.lua
+++ b/Orbit/Core/Engine/UnitButton/UnitButtonCore.lua
@@ -61,7 +61,7 @@ function CoreMixin:CreateCanvasPreview(options)
     -- [ HEALTH BAR ] --------------------------------------------------------------------------------
     local Pixel = Engine.Pixel
     local scale = self:GetEffectiveScale() or 1
-    local inset = preview.borderPixelSize or Pixel:Snap(borderSize, scale)
+    local inset = preview.borderPixelSize or Pixel:Multiple(borderSize, scale)
 
     local bar = CreateFrame("StatusBar", nil, preview)
     bar:SetPoint("TOPLEFT", inset, -inset)

--- a/Orbit/Core/Mixins/UnitFrameMixin.lua
+++ b/Orbit/Core/Mixins/UnitFrameMixin.lua
@@ -193,7 +193,7 @@ function Mixin:UpdateFrameLayout(frame, borderSize, options)
     local scale = frame:GetEffectiveScale()
     local powerBarRatio = options.powerBarRatio or DEFAULT_POWER_BAR_RATIO
     local powerHeight = showPowerBar and Pixel:Snap(height * powerBarRatio, scale) or 0
-    local inset = Pixel:Snap(frame.borderPixelSize or borderSize or 0, scale)
+    local inset = frame.borderPixelSize or Pixel:Multiple(borderSize or 0, scale)
 
     if frame.Power then
         if showPowerBar then

--- a/Orbit_BossFrames/BossFrame.lua
+++ b/Orbit_BossFrames/BossFrame.lua
@@ -47,8 +47,8 @@ end
 
 local function CreatePowerBar(parent, unit, plugin)
     local power = CreateFrame("StatusBar", nil, parent)
-    power:SetPoint("BOTTOMLEFT", 1, 1)
-    power:SetPoint("BOTTOMRIGHT", -1, 1)
+    power:SetPoint("BOTTOMLEFT", 0, 0)
+    power:SetPoint("BOTTOMRIGHT", 0, 0)
     power:SetHeight(parent:GetHeight() * POWER_BAR_HEIGHT_RATIO)
     power:SetStatusBarTexture("Interface\\TargetingFrame\\UI-TargetingFrame-BarFill")
     power:SetMinMaxValues(0, 1)

--- a/Orbit_CooldownManager/TrackedCharges.lua
+++ b/Orbit_CooldownManager/TrackedCharges.lua
@@ -42,6 +42,10 @@ local function SnapToPixel(value, scale)
     return OrbitEngine.Pixel:Snap(value, scale)
 end
 
+local function PixelMultiple(count, scale)
+    return OrbitEngine.Pixel:Multiple(count, scale)
+end
+
 local function IsChargeSpell(spellId)
     if not spellId then
         return false, nil
@@ -506,7 +510,7 @@ function Plugin:LayoutChargeBars()
 end
 
 function Plugin:SkinChargeButtons(frame, maxCharges, totalWidth, height, borderSize, spacing, texture, sysIndex, bgColor, scale)
-    local snappedGap = SnapToPixel(spacing - 1, scale)
+    local snappedGap = PixelMultiple(spacing - 1, scale)
     local totalSpacing = (maxCharges - 1) * snappedGap
     local usableWidth = totalWidth - totalSpacing
     local btnWidth = SnapToPixel(usableWidth / maxCharges, scale)
@@ -592,7 +596,7 @@ function Plugin:SetupChargeBarCanvasPreview(frame, sysIndex)
         preview.previewScale = 1
         preview.components = {}
 
-        local snappedGap = SnapToPixel(spacing - 1, scale)
+        local snappedGap = PixelMultiple(spacing - 1, scale)
         local totalSpacing = (maxCharges - 1) * snappedGap
         local usableWidth = width - totalSpacing
         local btnWidth = SnapToPixel(usableWidth / maxCharges, scale)

--- a/Orbit_PartyFrames/FrameFactory.lua
+++ b/Orbit_PartyFrames/FrameFactory.lua
@@ -6,13 +6,13 @@ Orbit.PartyFrameFactoryMixin = {}
 
 -- [ CONSTANTS ]-------------------------------------------------------------------------------------
 local POWER_BAR_HEIGHT_RATIO = Orbit.PartyFrameHelpers.LAYOUT.PowerBarRatio
+local SELECTION_BORDER_THICKNESS = 2
 
 -- [ POWER BAR CREATION ]----------------------------------------------------------------------------
-
 function Orbit.PartyFrameFactoryMixin:CreatePowerBar(parent, unit, plugin)
     local power = CreateFrame("StatusBar", nil, parent)
-    power:SetPoint("BOTTOMLEFT", 1, 1)
-    power:SetPoint("BOTTOMRIGHT", -1, 1)
+    power:SetPoint("BOTTOMLEFT", 0, 0)
+    power:SetPoint("BOTTOMRIGHT", 0, 0)
     power:SetHeight(parent:GetHeight() * POWER_BAR_HEIGHT_RATIO)
     power:SetStatusBarTexture("Interface\\TargetingFrame\\UI-StatusBar")
     power:SetFrameLevel(parent:GetFrameLevel() + Orbit.Constants.Levels.Cooldown)
@@ -62,7 +62,7 @@ function Orbit.PartyFrameFactoryMixin:CreateStatusIcons(frame)
     frame.SelectionHighlight:SetColorTexture(1, 1, 1, 0)
     frame.SelectionHighlight:SetDrawLayer("ARTWORK", Orbit.Constants.Layers.Highlight)
     frame.SelectionHighlight:Hide()
-    local borderThickness = 2
+    local borderThickness = OrbitEngine.Pixel:Multiple(SELECTION_BORDER_THICKNESS, frame:GetEffectiveScale() or 1)
     frame.SelectionBorders = {}
     for _, edge in pairs({ "TOP", "BOTTOM", "LEFT", "RIGHT" }) do
         local border = frame.BorderOverlay:CreateTexture(nil, "ARTWORK")
@@ -167,6 +167,8 @@ function Orbit.PartyFrameFactoryMixin:RegisterFrameEvents(frame, unit)
         "GROUP_ROSTER_UPDATE",
         "PLAYER_TARGET_CHANGED",
         "RAID_TARGET_UPDATE",
+        "PLAYER_REGEN_DISABLED",
+        "PLAYER_REGEN_ENABLED",
     }
     for _, event in ipairs(globalEvents) do
         frame:RegisterEvent(event)

--- a/Orbit_PlayerUtilities/PlayerPower.lua
+++ b/Orbit_PlayerUtilities/PlayerPower.lua
@@ -19,6 +19,7 @@ local POWER_CURVE_CONFIG = {
     { key = "RunicPowerColorCurve", label = "Runic Power Colour", powerType = Enum.PowerType.RunicPower },
     { key = "LunarPowerColorCurve", label = "Astral Power Colour", powerType = Enum.PowerType.LunarPower },
     { key = "FuryColorCurve", label = "Fury Colour", powerType = Enum.PowerType.Fury },
+    { key = "InsanityColorCurve", label = "Insanity Colour", powerType = Enum.PowerType.Insanity },
 }
 
 local CLASS_POWER_TYPES = {
@@ -26,7 +27,7 @@ local CLASS_POWER_TYPES = {
     PALADIN = { Enum.PowerType.Mana },
     HUNTER = { Enum.PowerType.Focus },
     ROGUE = { Enum.PowerType.Energy },
-    PRIEST = { Enum.PowerType.Mana },
+    PRIEST = { Enum.PowerType.Mana, Enum.PowerType.Insanity },
     DEATHKNIGHT = { Enum.PowerType.RunicPower },
     SHAMAN = { Enum.PowerType.Mana },
     MAGE = { Enum.PowerType.Mana },
@@ -70,6 +71,7 @@ local Plugin = Orbit:RegisterPlugin("Player Power", SYSTEM_ID, {
         RunicPowerColorCurve = { pins = { { position = 0, color = { r = 0, g = 0.82, b = 1, a = 1 } } } },
         LunarPowerColorCurve = { pins = { { position = 0, color = { r = 0.95, g = 0.9, b = 0.6, a = 1 } } } },
         FuryColorCurve = { pins = { { position = 0, color = { r = 1, g = 0.6, b = 0.2, a = 1 } } } },
+        InsanityColorCurve = { pins = { { position = 0, color = { r = 0.6, g = 0.2, b = 1.0, a = 1 } } } },
         EbonMightColorCurve = { pins = { { position = 0, color = { r = 0.2, g = 0.8, b = 0.4, a = 1 } } } },
         Opacity = 100,
         OutOfCombatFade = false,

--- a/Orbit_UnitFrames/Focus/FocusPower.lua
+++ b/Orbit_UnitFrames/Focus/FocusPower.lua
@@ -106,7 +106,7 @@ function Plugin:OnLoad()
         Orbit.Skin:SkinBorder(preview, preview, borderSize)
 
         -- Power Bar
-        local inset = preview.borderPixelSize or OrbitEngine.Pixel:Snap(borderSize, self:GetEffectiveScale() or 1)
+        local inset = preview.borderPixelSize or OrbitEngine.Pixel:Multiple(borderSize, self:GetEffectiveScale() or 1)
         local bar = CreateFrame("StatusBar", nil, preview)
         bar:SetPoint("TOPLEFT", inset, -inset)
         bar:SetPoint("BOTTOMRIGHT", -inset, inset)

--- a/Orbit_UnitFrames/Target/TargetPower.lua
+++ b/Orbit_UnitFrames/Target/TargetPower.lua
@@ -106,7 +106,7 @@ function Plugin:OnLoad()
         Orbit.Skin:SkinBorder(preview, preview, borderSize)
 
         -- Power Bar
-        local inset = preview.borderPixelSize or OrbitEngine.Pixel:Snap(borderSize, self:GetEffectiveScale() or 1)
+        local inset = preview.borderPixelSize or OrbitEngine.Pixel:Multiple(borderSize, self:GetEffectiveScale() or 1)
         local bar = CreateFrame("StatusBar", nil, preview)
         bar:SetPoint("TOPLEFT", inset, -inset)
         bar:SetPoint("BOTTOMRIGHT", -inset, inset)


### PR DESCRIPTION
- Trying some new pixel-perfect stuff
- Divider size on Resource bars should now be accurate
- Shadow Priest can now change color of Insanity Bar
- Inifinite duration spells on Cooldown Manager will now be colored if active (ie. Absolute Corruption)
- Width Sync frame issue with cooldown manager spells that are lost and then gained again quickly
- Hopeful bugfix for Tracked Cooldowns taint errors (stack count changing in-combat during a refresh, re:  Guardian of the ancient kings report)