### PR TITLE
Add strata controls for frames and canvas components

### DIFF
--- a/Orbit/Core/CanvasMode/ComponentSettings.lua
+++ b/Orbit/Core/CanvasMode/ComponentSettings.lua
@@ -130,6 +130,24 @@ function Settings:Open(componentKey, container, plugin, systemIndex)
             local r, g, b, a = visual:GetTextColor()
             return { r = r, g = g, b = b, a = a or 1 }
         elseif key == "Scale" then return 1.0 end
+        if key == "Strata" then
+            if visual.GetFrameStrata then
+                return visual:GetFrameStrata()
+            elseif visual.GetDrawLayer then
+                local layer = visual:GetDrawLayer()
+                for strata, drawLayer in pairs(Orbit.Constants.Strata.DrawLayerByStrata) do
+                    if drawLayer == layer then return strata end
+                end
+                return "MEDIUM"
+            end
+        elseif key == "Level" then
+            if visual.GetFrameLevel then
+                return visual:GetFrameLevel()
+            elseif visual.GetDrawLayer then
+                local _, sublevel = visual:GetDrawLayer()
+                return sublevel or 0
+            end
+        end
         return nil
     end
 

--- a/Orbit/Core/CanvasMode/ComponentSettingsPreview.lua
+++ b/Orbit/Core/CanvasMode/ComponentSettingsPreview.lua
@@ -194,6 +194,7 @@ function Settings:ApplyStyle(container, key, value)
 
     if not container or not container.visual then return end
     local visual = container.visual
+    local layerTarget = (visual.SetFrameStrata or visual.SetDrawLayer) and visual or container
 
     if key == "FontSize" and visual.SetFont then
         local font, _, flags = visual:GetFont()
@@ -268,6 +269,8 @@ function Settings:ApplyStyle(container, key, value)
         end
         local plugin = self.plugin
         if plugin and plugin.SchedulePreviewUpdate then plugin:SchedulePreviewUpdate() end
+    elseif key == "Strata" or key == "Level" then
+        OrbitEngine.OverrideUtils.ApplyLayerOverrides(layerTarget, self.currentOverrides or {})
     end
 end
 

--- a/Orbit/Core/CanvasMode/ComponentSettingsSchema.lua
+++ b/Orbit/Core/CanvasMode/ComponentSettingsSchema.lua
@@ -31,22 +31,33 @@ local ICON_SIZE_CONTROL = {
     formatter = function(v) return v .. "px" end,
 }
 
+local STRATA_CONTROLS = {
+    { type = "dropdown", key = "Strata", label = "Strata", options = Orbit.Constants.Strata.FrameOptions, default = "MEDIUM" },
+    { type = "slider", key = "Level", label = "Level", min = Orbit.Constants.Strata.FrameLevel.Min, max = Orbit.Constants.Strata.FrameLevel.Max, step = Orbit.Constants.Strata.FrameLevel.Step },
+}
+
 -- [ PRESETS ]----------------------------------------------------------------------------------------
 local STATIC_TEXT = {
     { type = "font", key = "Font", label = "Font" },
     { type = "slider", key = "FontSize", label = "Size", min = 6, max = 32, step = 1 },
     { type = "colorcurve", key = "CustomColorCurve", label = "Color", singleColor = true },
+    STRATA_CONTROLS[1],
+    STRATA_CONTROLS[2],
 }
 
 local DYNAMIC_TEXT = {
     { type = "font", key = "Font", label = "Font" },
     { type = "slider", key = "FontSize", label = "Size", min = 6, max = 32, step = 1 },
     { type = "colorcurve", key = "CustomColorCurve", label = "Color", singleColor = false },
+    STRATA_CONTROLS[1],
+    STRATA_CONTROLS[2],
 }
 
 local TEXT_NO_COLOR = {
     { type = "font", key = "Font", label = "Font" },
     { type = "slider", key = "FontSize", label = "Size", min = 6, max = 32, step = 1 },
+    STRATA_CONTROLS[1],
+    STRATA_CONTROLS[2],
 }
 
 local AURA_GRID = {
@@ -70,9 +81,9 @@ local PANDEMIC_GLOW = {
 -- [ COMPONENT TYPE SCHEMAS ]-------------------------------------------------------------------------
 Schema.TYPE_SCHEMAS = {
     FontString = Compose(DYNAMIC_TEXT),
-    Texture = { controls = { SCALE_CONTROL } },
-    IconFrame = { controls = { ICON_SIZE_CONTROL } },
-    CyclingAtlas = { controls = { ICON_SIZE_CONTROL } },
+    Texture = { controls = { SCALE_CONTROL, STRATA_CONTROLS[1], STRATA_CONTROLS[2] } },
+    IconFrame = { controls = { ICON_SIZE_CONTROL, STRATA_CONTROLS[1], STRATA_CONTROLS[2] } },
+    CyclingAtlas = { controls = { ICON_SIZE_CONTROL, STRATA_CONTROLS[1], STRATA_CONTROLS[2] } },
 }
 
 -- [ KEY SCHEMAS ]------------------------------------------------------------------------------------
@@ -200,4 +211,27 @@ function Schema.GetComponentFamily(container)
     if objType == "FontString" then return "FontString"
     elseif objType == "Texture" then return "Texture" end
     return nil
+end
+
+local function EnsureLayerControls(schema)
+    if not schema or not schema.controls then return end
+    local hasStrata, hasLevel = false, false
+    for _, control in ipairs(schema.controls) do
+        if control.key == "Strata" then hasStrata = true end
+        if control.key == "Level" then hasLevel = true end
+    end
+    if not hasStrata then
+        schema.controls[#schema.controls + 1] = STRATA_CONTROLS[1]
+    end
+    if not hasLevel then
+        schema.controls[#schema.controls + 1] = STRATA_CONTROLS[2]
+    end
+end
+
+for _, schema in pairs(Schema.TYPE_SCHEMAS) do
+    EnsureLayerControls(schema)
+end
+
+for _, schema in pairs(Schema.KEY_SCHEMAS) do
+    EnsureLayerControls(schema)
 end

--- a/Orbit/Core/CanvasMode/OverrideUtils.lua
+++ b/Orbit/Core/CanvasMode/OverrideUtils.lua
@@ -10,6 +10,28 @@ local LSM = LibStub("LibSharedMedia-3.0")
 local OverrideUtils = {}
 Engine.OverrideUtils = OverrideUtils
 
+function OverrideUtils.ApplyLayerOverrides(element, overrides)
+    if not element or not overrides then return end
+
+    local strata = overrides.Strata
+    local level = overrides.Level
+
+    if strata and element.SetFrameStrata then
+        element:SetFrameStrata(strata)
+    end
+
+    if level ~= nil and element.SetFrameLevel then
+        element:SetFrameLevel(level)
+        return
+    end
+
+    if (strata or level ~= nil) and element.SetDrawLayer then
+        local currentLayer = element.GetDrawLayer and select(1, element:GetDrawLayer()) or "ARTWORK"
+        local drawLayer = strata and Orbit.Constants.Strata.DrawLayerByStrata[strata] or currentLayer
+        element:SetDrawLayer(drawLayer or "ARTWORK", level or 0)
+    end
+end
+
 -- [ TEXT COLOR ]-------------------------------------------------------------------------------------
 -- Apply color to a text element.
 -- Priority: UseClassColour > CustomColorCurve > CustomColorValue > Global FontColorCurve > white
@@ -205,4 +227,5 @@ function OverrideUtils.ApplyOverrides(element, overrides, defaults, unit, classF
     -- Scale (Textures and scalable elements)
     OverrideUtils.ApplyScaleOverride(element, overrides)
     OverrideUtils.ApplyIconSizeOverride(element, overrides)
+    OverrideUtils.ApplyLayerOverrides(element, overrides)
 end

--- a/Orbit/Core/Config/ConfigRenderer.lua
+++ b/Orbit/Core/Config/ConfigRenderer.lua
@@ -7,9 +7,69 @@ Engine.Config = {}
 local Config = Engine.Config
 local Layout = Engine.Layout
 
+local function BuildRenderedSchema(dialog, plugin, systemFrame, systemIndex, schema)
+    local controls = {}
+    for _, def in ipairs(schema.controls or schema) do
+        controls[#controls + 1] = def
+    end
+
+    if plugin and systemFrame and systemFrame.systemFrame then
+        systemFrame = systemFrame.systemFrame
+    end
+
+    if dialog == Orbit.SettingsDialog and plugin and systemFrame and systemFrame.GetFrameLevel and not schema.hideLayerControls then
+        controls[#controls + 1] = {
+            type = "dropdown",
+            key = "FrameStrata",
+            label = "Frame Strata",
+            options = Constants.Strata.FrameOptions,
+            default = "MEDIUM",
+            getValue = function()
+                return plugin:GetSetting(systemIndex, "FrameStrata") or systemFrame:GetFrameStrata() or "MEDIUM"
+            end,
+            onChange = function(value)
+                plugin:SetSetting(systemIndex, "FrameStrata", value)
+                if plugin.ApplyStoredFrameLayers then
+                    plugin:ApplyStoredFrameLayers(systemFrame, systemIndex)
+                end
+                if Engine.Frame then Engine.Frame:ForceUpdateSelection(systemFrame) end
+            end,
+        }
+        controls[#controls + 1] = {
+            type = "slider",
+            key = "FrameLevel",
+            label = "Frame Level",
+            min = Constants.Strata.FrameLevel.Min,
+            max = Constants.Strata.FrameLevel.Max,
+            step = Constants.Strata.FrameLevel.Step,
+            default = Constants.Strata.FrameLevel.Default,
+            getValue = function()
+                local value = plugin:GetSetting(systemIndex, "FrameLevel")
+                if value == nil and systemFrame.GetFrameLevel then
+                    value = systemFrame:GetFrameLevel()
+                end
+                return value or Constants.Strata.FrameLevel.Default
+            end,
+            onChange = function(value)
+                plugin:SetSetting(systemIndex, "FrameLevel", value)
+                if plugin.ApplyStoredFrameLayers then
+                    plugin:ApplyStoredFrameLayers(systemFrame, systemIndex)
+                end
+                if Engine.Frame then Engine.Frame:ForceUpdateSelection(systemFrame) end
+            end,
+        }
+    end
+
+    local rendered = {}
+    for k, v in pairs(schema) do rendered[k] = v end
+    rendered.controls = controls
+    return rendered
+end
+
 function Config:Render(dialog, systemFrame, plugin, schema, tabKey)
     local systemIndex = systemFrame.systemIndex or plugin.system or 1
     local Constants = Constants
+    schema = BuildRenderedSchema(dialog, plugin, systemFrame, systemIndex, schema)
 
     local footerHeight = Constants.Footer.TopPadding + Constants.Footer.ButtonHeight + Constants.Footer.BottomPadding
     local contentWidthWithScroll = Constants.Panel.Width - Constants.Panel.ScrollbarWidth - (Constants.Panel.ContentPadding * 2)

--- a/Orbit/Core/EditMode/Frame/Position/Persistence.lua
+++ b/Orbit/Core/EditMode/Frame/Position/Persistence.lua
@@ -103,6 +103,9 @@ function Persistence:AttachSettingsListener(frame, plugin, systemIndex)
     -- (Fixes data loss for frames created manually without FrameFactory)
     frame.orbitPlugin = plugin
     frame.systemIndex = systemIndex
+    if plugin.RegisterFrameForSettings then
+        plugin:RegisterFrameForSettings(frame, systemIndex)
+    end
 
     -- Shared logic to refresh dialog (Trailing Debounce)
     local refreshTimer

--- a/Orbit/Core/Init.lua
+++ b/Orbit/Core/Init.lua
@@ -149,7 +149,16 @@ function Orbit:InitializePlugins()
                     if self.frame then self.frame.orbitDisabled = true; self.frame:Hide() end
                     return
                 end
-                return original(self, ...)
+                local result = original(self, ...)
+                if self.ApplyStoredFrameLayers then
+                    local target = ...
+                    if type(target) == "table" and target.GetFrameLevel then
+                        self:ApplyStoredFrameLayers(target, target.systemIndex)
+                    else
+                        self:ApplyStoredFrameLayers()
+                    end
+                end
+                return result
             end
             plugin._applyWrapped = true
         end

--- a/Orbit/Core/Plugin/PluginMixin.lua
+++ b/Orbit/Core/Plugin/PluginMixin.lua
@@ -15,6 +15,16 @@ end
 ---@class OrbitPluginMixin
 Orbit.PluginMixin = {}
 
+local function ApplyFrameLayerSettings(frame, strata, level)
+    if not frame then return end
+    if strata and frame.SetFrameStrata then
+        frame:SetFrameStrata(strata)
+    end
+    if level ~= nil and frame.SetFrameLevel then
+        frame:SetFrameLevel(level)
+    end
+end
+
 function Orbit.PluginMixin:Init() end
 
 function Orbit.PluginMixin:OnLoad() end
@@ -80,6 +90,25 @@ end
 function Orbit.PluginMixin:OnCanvasApply()
     if self.ApplySettings then self:ApplySettings() end
     if self.SchedulePreviewUpdate then self:SchedulePreviewUpdate() end
+end
+
+function Orbit.PluginMixin:RegisterFrameForSettings(frame, systemIndex)
+    if not frame then return end
+    self._orbitFramesBySystemIndex = self._orbitFramesBySystemIndex or {}
+    self._orbitFramesBySystemIndex[systemIndex or frame.systemIndex or 1] = frame
+end
+
+function Orbit.PluginMixin:ApplyStoredFrameLayers(frame, systemIndex)
+    if frame and frame.GetFrameLevel then
+        local idx = systemIndex or frame.systemIndex or 1
+        ApplyFrameLayerSettings(frame, self:GetSetting(idx, "FrameStrata"), self:GetSetting(idx, "FrameLevel"))
+        return
+    end
+
+    if not self._orbitFramesBySystemIndex then return end
+    for idx, registeredFrame in pairs(self._orbitFramesBySystemIndex) do
+        ApplyFrameLayerSettings(registeredFrame, self:GetSetting(idx, "FrameStrata"), self:GetSetting(idx, "FrameLevel"))
+    end
 end
 
 -- Subscribe to live preview updates during Canvas Mode editing

--- a/Orbit/Core/Shared/Constants.lua
+++ b/Orbit/Core/Shared/Constants.lua
@@ -138,6 +138,30 @@ C.Settings = {
     Texture = { Default = "Melli" },
 }
 
+C.Strata = {
+    FrameOptions = {
+        { text = "Background", value = "BACKGROUND" },
+        { text = "Low", value = "LOW" },
+        { text = "Medium", value = "MEDIUM" },
+        { text = "High", value = "HIGH" },
+        { text = "Dialog", value = "DIALOG" },
+        { text = "Fullscreen", value = "FULLSCREEN" },
+        { text = "Fullscreen Dialog", value = "FULLSCREEN_DIALOG" },
+        { text = "Tooltip", value = "TOOLTIP" },
+    },
+    DrawLayerByStrata = {
+        BACKGROUND = "BACKGROUND",
+        LOW = "BORDER",
+        MEDIUM = "ARTWORK",
+        HIGH = "OVERLAY",
+        DIALOG = "OVERLAY",
+        FULLSCREEN = "HIGHLIGHT",
+        FULLSCREEN_DIALOG = "HIGHLIGHT",
+        TOOLTIP = "HIGHLIGHT",
+    },
+    FrameLevel = { Min = 0, Max = 500, Step = 1, Default = 0 },
+}
+
 -- [ BORDER STYLE ]---------------------------------------------------------------------------------
 C.BorderStyle = {
     Default = "flat",


### PR DESCRIPTION
## Summary

Adds layer controls to Orbit frame settings and Canvas Mode component settings.

## Change

- adds `Frame Strata` and `Frame Level` to Orbit frame settings
- adds `Strata` and `Level` to Canvas Mode component settings
- persists and reapplies frame layer settings
- maps canvas texture/fontstring layers to draw layer/sublevel where WoW does not support true frame strata

<img width="850" height="558" alt="image" src="https://github.com/user-attachments/assets/411e6e27-d58f-4697-a5b5-31eef063777e" />
<img width="806" height="603" alt="image" src="https://github.com/user-attachments/assets/6395f75b-7b2f-457c-91e6-1e3771e284e4" />
