### PR TITLE
Fix detached aura grids restoring stale anchors

### DIFF
--- a/Orbit/Core/EditMode/Frame/Position/Persistence.lua
+++ b/Orbit/Core/EditMode/Frame/Position/Persistence.lua
@@ -62,6 +62,9 @@ function Persistence:RestorePosition(frame, plugin, systemIndex)
     -- Restore Position
     local pos = plugin:GetSetting(systemIndex, "Position")
     if pos and pos.point then
+        if Engine.FrameAnchor and Engine.FrameAnchor:GetAnchorParent(frame) then
+            Engine.FrameAnchor:BreakAnchor(frame, true)
+        end
         local x, y = pos.x, pos.y
         if Engine.Pixel then
             x, y = Engine.Pixel:SnapPosition(x, y, pos.point, frame:GetWidth(), frame:GetHeight(), frame:GetEffectiveScale())

--- a/Orbit/Core/UnitDisplay/UnitAuraGridMixin.lua
+++ b/Orbit/Core/UnitDisplay/UnitAuraGridMixin.lua
@@ -290,9 +290,13 @@ function Mixin:CreateAuraGridPlugin(config)
     -- Default position: anchor to parent frame or fallback
     local parentFrame = _G[config.anchorParent]
     if parentFrame then
-        Frame:ClearAllPoints()
-        Frame:SetPoint("TOPLEFT", parentFrame, "BOTTOMLEFT", 0, config.anchorGap or -50)
-        OrbitEngine.Frame:CreateAnchor(Frame, parentFrame, "BOTTOM", config.anchorGap or 50, nil, "LEFT")
+        local hasSavedAnchor = self:GetSetting(1, "Anchor")
+        local hasSavedPosition = self:GetSetting(1, "Position")
+        if not hasSavedAnchor and not hasSavedPosition then
+            Frame:ClearAllPoints()
+            Frame:SetPoint("TOPLEFT", parentFrame, "BOTTOMLEFT", 0, config.anchorGap or -50)
+            OrbitEngine.Frame:CreateAnchor(Frame, parentFrame, "BOTTOM", config.anchorGap or 50, nil, "LEFT")
+        end
     else
         Frame:SetPoint("CENTER", UIParent, "CENTER", config.defaultX or 0, config.defaultY or -220)
     end


### PR DESCRIPTION
## Summary

Fixes detached aura grids like target buffs/debuffs and player buffs restoring with stale anchor behavior after reload.

## Change

- skips recreating the default parent anchor when saved anchor/position data already exists
- breaks any existing runtime anchor before restoring a saved free position

## Testing

- moved detached aura grids away from their default parent
- reloaded
- confirmed they stayed detached and kept their size/position
<img width="1052" height="647" alt="image" src="https://github.com/user-attachments/assets/2524fd2d-b40f-448c-b1e5-878c11850937" />
<img width="1019" height="625" alt="image" src="https://github.com/user-attachments/assets/6636c9ec-3313-48a0-a662-1475cd812f08" />
