### PR TITLE
Fix stale cooldown group borders after padding change

### DIFF
--- a/Orbit/Core/Skinning/Skin.lua
+++ b/Orbit/Core/Skinning/Skin.lua
@@ -107,6 +107,7 @@ function Skin:ClearIconGroupBorder(container)
     if not container then return end
     -- NOTE: _isIconContainer is NOT cleared here — it reflects frame type, not border style.
     self:ClearNineSliceBorder(container)
+    if container._borderFrame then container._borderFrame:Hide() end
 end
 
 -- Group border functions → GroupBorder.lua


### PR DESCRIPTION
## Summary

Fixes cooldown manager group borders staying visible after changing `Icon Padding` from `0` back to a non-zero value.

## Change

When clearing an icon group border, also hide the container pixel border frame so the old whole-container border does not remain behind the per-icon borders.

## Testing

- set `Icon Padding` to `0`
- confirmed a single container border appears
- changed `Icon Padding` back to `1` or `2`
- confirmed the container border clears correctly on both CDM and Utility


<img width="455" height="225" alt="image" src="https://github.com/user-attachments/assets/68d9b132-9b33-4a17-8c6e-5a79cf514839" />

<img width="579" height="335" alt="image" src="https://github.com/user-attachments/assets/ea239b34-be78-4532-8aa1-abb6de98ad6b" />
