### PR TITLE
Add independent mouseover visibility option

### DIFF
--- a/Orbit/Core/Plugin/OOCFadeMixin.lua
+++ b/Orbit/Core/Plugin/OOCFadeMixin.lua
@@ -15,8 +15,7 @@ local ManagedFrames = {}
 
 -- [ VISIBILITY LOGIC ]------------------------------------------------------------------------------
 
-local function ShouldShowFrame(frame)
-    if frame and not frame:IsShown() then return false end
+local function IsForceVisible()
     if Orbit:IsEditMode() then
         return true
     end
@@ -24,8 +23,24 @@ local function ShouldShowFrame(frame)
         return true
     end
     local cursorType = GetCursorInfo()
-    if cursorType == "spell" or cursorType == "item" then
+    return cursorType == "spell" or cursorType == "item"
+end
+
+local function IsMouseoverOnlyEnabled(data)
+    return data and data.plugin and data.plugin.GetSetting and data.plugin:GetSetting(data.systemIndex, "MouseoverOnly")
+end
+
+local function IsHoverEnabled(data)
+    return (data and data.enableHover) or IsMouseoverOnlyEnabled(data)
+end
+
+local function ShouldShowFrame(frame, data)
+    if frame and not frame:IsShown() then return false end
+    if IsForceVisible() then
         return true
+    end
+    if IsMouseoverOnlyEnabled(data) then
+        return frame and frame.orbitMouseOver
     end
     return InCombatLockdown() or UnitAffectingCombat("player") or UnitExists("target") or (frame and frame.orbitMouseOver)
 end
@@ -61,17 +76,24 @@ local function UpdateFrameVisibility(frame, fadeEnabled, data)
         return
     end
     if Orbit.MountedVisibility:ShouldHide() then return end
-    local includeChildren = data and not data.enableHover
-    if not fadeEnabled then
+
+    local includeChildren = data and not IsHoverEnabled(data)
+    local mouseoverOnly = IsMouseoverOnlyEnabled(data)
+
+    if not fadeEnabled and not mouseoverOnly then
         SetFrameMouseEnabled(frame, true, includeChildren)
-        return
-    end
-    if ShouldShowFrame(frame) then
-        SetFrameMouseEnabled(frame, true, includeChildren)
-        -- Apply Opacity setting instead of forcing alpha=1 (new precedence: OOC → Opacity → MouseOver)
         if data and data.plugin then
             local opacity = data.plugin:GetSetting(data.systemIndex, "Opacity") or 100
-            local minAlpha = opacity / 100
+            frame:SetAlpha(opacity / 100)
+        end
+        return
+    end
+
+    if ShouldShowFrame(frame, data) then
+        SetFrameMouseEnabled(frame, true, includeChildren)
+        if data and data.plugin then
+            local opacity = data.plugin:GetSetting(data.systemIndex, "Opacity") or 100
+            local minAlpha = mouseoverOnly and 0 or (opacity / 100)
             local isEditMode = Orbit:IsEditMode()
             Orbit.Animation:ApplyHoverFade(frame, minAlpha, 1, isEditMode)
         end
@@ -98,13 +120,12 @@ EventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
 
 EventFrame:SetScript("OnEvent", function(self, event)
     if event == "PLAYER_REGEN_DISABLED" then
-        UpdateAllFrames() -- Update immediately before combat lockdown
+        UpdateAllFrames()
     else
         C_Timer.After(0.05, UpdateAllFrames)
     end
 end)
 
--- Hook Edit Mode show/hide
 if EditModeManagerFrame then
     EditModeManagerFrame:HookScript("OnShow", function()
         C_Timer.After(0.1, UpdateAllFrames)
@@ -114,7 +135,6 @@ if EditModeManagerFrame then
     end)
 end
 
--- Hook CooldownViewerSettings show/hide (delayed for load order)
 C_Timer.After(2, function()
     if CooldownViewerSettings then
         CooldownViewerSettings:HookScript("OnShow", function()
@@ -128,29 +148,36 @@ end)
 
 -- [ MIXIN FUNCTIONS ]-------------------------------------------------------------------------------
 
---- Apply Out of Combat Fade behavior to a frame
 function Mixin:ApplyOOCFade(frame, plugin, systemIndex, settingKey, enableHover)
     if not frame or not plugin then
         return
     end
-    settingKey = settingKey or "OutOfCombatFade"
-    ManagedFrames[frame] = { plugin = plugin, systemIndex = systemIndex, settingKey = settingKey, enableHover = enableHover or false }
 
-    -- Create hover ticker if not exists (uses MouseIsOver for child-inclusive detection)
+    settingKey = settingKey or "OutOfCombatFade"
+    ManagedFrames[frame] = {
+        plugin = plugin,
+        systemIndex = systemIndex,
+        settingKey = settingKey,
+        enableHover = enableHover or false,
+    }
+
     if not frame.orbitOOCHoverTicker then
         local hoverTicker = CreateFrame("Frame", nil, frame)
         hoverTicker:SetScript("OnUpdate", function(self, elapsed)
             self.timer = (self.timer or 0) + elapsed
             if self.timer < Orbit.Constants.Timing.HoverCheckInterval then return end
             self.timer = 0
+
             local parent = self:GetParent()
             if not parent:IsShown() then return end
+
             local isOver = MouseIsOver(parent)
             if Orbit.MountedVisibility:ShouldHide() then return end
+
             if isOver and not parent.orbitMouseOver then
                 parent.orbitMouseOver = true
                 local data = ManagedFrames[parent]
-                if data and data.plugin:GetSetting(data.systemIndex, data.settingKey) then
+                if data and (data.plugin:GetSetting(data.systemIndex, data.settingKey) or IsMouseoverOnlyEnabled(data)) then
                     parent:SetAlpha(1)
                 end
             elseif not isOver and parent.orbitMouseOver then
@@ -164,30 +191,29 @@ function Mixin:ApplyOOCFade(frame, plugin, systemIndex, settingKey, enableHover)
         frame.orbitOOCHoverTicker = hoverTicker
     end
 
-    -- Show/hide ticker based on enableHover setting (allows dynamic toggle)
-    if enableHover then
+    if IsHoverEnabled(ManagedFrames[frame]) then
         frame.orbitOOCHoverTicker:Show()
     else
         frame.orbitOOCHoverTicker:Hide()
         frame.orbitMouseOver = nil
     end
 
-    -- Hook SetAlpha to prevent external override when OOC fade should hide
     if not frame.orbitOOCSetAlphaHooked then
         local originalSetAlpha = frame.SetAlpha
         frame.SetAlpha = function(self, alpha)
             local data = ManagedFrames[self]
-            if data and data.plugin:GetSetting(data.systemIndex, data.settingKey) and not ShouldShowFrame(self) and alpha > 0 and not Orbit.MountedVisibility:ShouldHide() then
+            if data and (data.plugin:GetSetting(data.systemIndex, data.settingKey) or IsMouseoverOnlyEnabled(data))
+                and not ShouldShowFrame(self, data) and alpha > 0 and not Orbit.MountedVisibility:ShouldHide() then
                 return originalSetAlpha(self, 0)
             end
             return originalSetAlpha(self, alpha)
         end
         frame.orbitOOCSetAlphaHooked = true
     end
+
     UpdateFrameVisibility(frame, plugin:GetSetting(systemIndex, settingKey), ManagedFrames[frame])
 end
 
---- Remove OOC Fade behavior from a frame
 function Mixin:RemoveOOCFade(frame)
     if not frame then
         return

--- a/Orbit/Plugins/ActionBars/ActionBars.lua
+++ b/Orbit/Plugins/ActionBars/ActionBars.lua
@@ -66,7 +66,7 @@ local Plugin = Orbit:RegisterPlugin("Action Bars", "Orbit_ActionBars", {
             Stacks = { anchorX = "LEFT", anchorY = "BOTTOM", offsetX = 2, offsetY = 2, justifyH = "LEFT" },
         },
         GlobalDisabledComponents = {},
-        OutOfCombatFade = false, ShowOnMouseover = true,
+        OutOfCombatFade = false, MouseoverOnly = false,
         KeypressColor = { r = 1, g = 1, b = 1, a = 0.6 },
         BackdropColour = { r = 0.08, g = 0.08, b = 0.08, a = 0.5 },
         OORColor = DEFAULT_OOR_COLOR, OOMColor = DEFAULT_OOM_COLOR, UnusableColor = DEFAULT_UNUSABLE_COLOR,
@@ -247,10 +247,8 @@ function Plugin:AddSettings(dialog, systemFrame)
         })
         table.insert(schema.controls, { type = "checkbox", key = "OutOfCombatFade", label = "Out of Combat Fade", default = false,
             onChange = function(val) self:SetSetting(systemIndex, "OutOfCombatFade", val); self:ApplySettings(container); if dialog.orbitTabCallback then dialog.orbitTabCallback() end end })
-        if self:GetSetting(systemIndex, "OutOfCombatFade") then
-            table.insert(schema.controls, { type = "checkbox", key = "ShowOnMouseover", label = "Show on Mouseover", default = true,
-                onChange = function(val) self:SetSetting(systemIndex, "ShowOnMouseover", val); self:ApplySettings(container) end })
-        end
+        table.insert(schema.controls, { type = "checkbox", key = "MouseoverOnly", label = "Mouseover Only", default = false,
+            onChange = function(val) self:SetSetting(systemIndex, "MouseoverOnly", val); self:ApplySettings(container) end })
     end
     schema.extraButtons = { { text = "Quick Keybind", callback = function()
         if EditModeManagerFrame and EditModeManagerFrame:IsShown() then HideUIPanel(EditModeManagerFrame) end
@@ -592,8 +590,7 @@ function Plugin:ApplySettings(frame)
     if not self.buttons[index] or #self.buttons[index] == 0 then self:ReparentButtons(index) end
     self:ApplyScale(actualFrame, index, "Scale")
     if index ~= PET_BAR_INDEX then
-        local enableHover = self:GetSetting(index, "ShowOnMouseover") ~= false
-        Orbit.OOCFadeMixin:ApplyOOCFade(actualFrame, self, index, "OutOfCombatFade", enableHover)
+        Orbit.OOCFadeMixin:ApplyOOCFade(actualFrame, self, index, "OutOfCombatFade", false)
     end
     self:ApplyMouseOver(actualFrame, index)
     self:LayoutButtons(index)

--- a/Orbit/Plugins/ActionBars/ActionBarsContainer.lua
+++ b/Orbit/Plugins/ActionBars/ActionBarsContainer.lua
@@ -70,8 +70,7 @@ function ABC:Create(plugin, config)
     end
     frame:Show()
     if config.index ~= PET_BAR_INDEX then
-        local enableHover = plugin:GetSetting(config.index, "ShowOnMouseover") ~= false
-        Orbit.OOCFadeMixin:ApplyOOCFade(frame, plugin, config.index, "OutOfCombatFade", enableHover)
+        Orbit.OOCFadeMixin:ApplyOOCFade(frame, plugin, config.index, "OutOfCombatFade", false)
     end
     return frame
 end

--- a/Orbit/Plugins/CooldownManager/CooldownManager.lua
+++ b/Orbit/Plugins/CooldownManager/CooldownManager.lua
@@ -40,7 +40,7 @@ local Plugin = Orbit:RegisterPlugin("Cooldown Manager", "Orbit_CooldownViewer", 
         ProcGlowType = Constants.PandemicGlow.DefaultType,
         ProcGlowColor = Constants.PandemicGlow.DefaultColor,
         OutOfCombatFade = false,
-        ShowOnMouseover = true,
+        MouseoverOnly = false,
         TrackedItems = {},
         KeypressColor = { r = 1, g = 1, b = 1, a = 0 },
         AssistedHighlight = false,
@@ -246,26 +246,23 @@ function Plugin:OnLoad()
 
     Orbit.EventBus:On("PLAYER_ENTERING_WORLD", function()
         for systemIndex, data in pairs(VIEWER_MAP) do
-            local enableHover = self:GetSetting(systemIndex, "ShowOnMouseover") ~= false
             if data.viewer then
-                Orbit.OOCFadeMixin:ApplyOOCFade(data.viewer, self, systemIndex, "OutOfCombatFade", enableHover)
+                Orbit.OOCFadeMixin:ApplyOOCFade(data.viewer, self, systemIndex, "OutOfCombatFade", false)
             end
             if (data.isTracked or data.isChargeBar) and data.anchor then
-                Orbit.OOCFadeMixin:ApplyOOCFade(data.anchor, self, systemIndex, "OutOfCombatFade", enableHover)
+                Orbit.OOCFadeMixin:ApplyOOCFade(data.anchor, self, systemIndex, "OutOfCombatFade", false)
             end
             for _, childData in pairs(self.activeChildren or {}) do
                 if childData.frame then
                     local csi = childData.frame.systemIndex
-                    local hover = self:GetSetting(csi, "ShowOnMouseover") ~= false
-                    Orbit.OOCFadeMixin:ApplyOOCFade(childData.frame, self, csi, "OutOfCombatFade", hover)
+                    Orbit.OOCFadeMixin:ApplyOOCFade(childData.frame, self, csi, "OutOfCombatFade", false)
                 end
             end
             -- Also apply to charge bar children
             for _, childData in pairs(self.activeChargeChildren or {}) do
                 if childData.frame then
                     local csi = childData.frame.systemIndex
-                    local hover = self:GetSetting(csi, "ShowOnMouseover") ~= false
-                    Orbit.OOCFadeMixin:ApplyOOCFade(childData.frame, self, csi, "OutOfCombatFade", hover)
+                    Orbit.OOCFadeMixin:ApplyOOCFade(childData.frame, self, csi, "OutOfCombatFade", false)
                 end
             end
             Orbit.OOCFadeMixin:RefreshAll()

--- a/Orbit/Plugins/CooldownManager/CooldownSettings.lua
+++ b/Orbit/Plugins/CooldownManager/CooldownSettings.lua
@@ -66,20 +66,18 @@ function CDM:AddSettings(dialog, systemFrame)
                     if dialog.orbitTabCallback then dialog.orbitTabCallback() end
                 end,
             })
-            if self:GetSetting(systemIndex, "OutOfCombatFade") then
-                table.insert(schema.controls, {
-                    type = "checkbox", key = "ShowOnMouseover", label = "Show on Mouseover", default = true,
-                    tooltip = "Reveal frame when mousing over it",
-                    onChange = function(val)
-                        self:SetSetting(systemIndex, "ShowOnMouseover", val)
-                        local data = VIEWER_MAP[systemIndex]
-                        if data and data.anchor then
-                            Orbit.OOCFadeMixin:ApplyOOCFade(data.anchor, self, systemIndex, "OutOfCombatFade", val)
-                            Orbit.OOCFadeMixin:RefreshAll()
-                        end
-                    end,
-                })
-            end
+            table.insert(schema.controls, {
+                type = "checkbox", key = "MouseoverOnly", label = "Mouseover Only", default = false,
+                tooltip = "Only show frame while mousing over it",
+                onChange = function(val)
+                    self:SetSetting(systemIndex, "MouseoverOnly", val)
+                    local data = VIEWER_MAP[systemIndex]
+                    if data and data.anchor then
+                        Orbit.OOCFadeMixin:ApplyOOCFade(data.anchor, self, systemIndex, "OutOfCombatFade", false)
+                        Orbit.OOCFadeMixin:RefreshAll()
+                    end
+                end,
+            })
             table.insert(schema.controls, {
                 type = "checkbox", key = "SmoothAnimation", label = "Smooth Animation", default = false,
                 tooltip = "Smoothly animate charge transitions",
@@ -95,20 +93,6 @@ function CDM:AddSettings(dialog, systemFrame)
                     self:RefreshChargeUpdateMethod()
                 end,
             })
-            if self:GetSetting(systemIndex, "OutOfCombatFade") then
-                table.insert(schema.controls, {
-                    type = "checkbox", key = "ShowOnMouseover", label = "Show on Mouseover", default = true,
-                    tooltip = "Reveal frame when mousing over it",
-                    onChange = function(val)
-                        self:SetSetting(systemIndex, "ShowOnMouseover", val)
-                        local data = VIEWER_MAP[systemIndex]
-                        if data and data.anchor then
-                            Orbit.OOCFadeMixin:ApplyOOCFade(data.anchor, self, systemIndex, "OutOfCombatFade", val)
-                            Orbit.OOCFadeMixin:RefreshAll()
-                        end
-                    end,
-                })
-            end
         end
 
         OrbitEngine.Config:Render(dialog, systemFrame, self, schema)
@@ -285,23 +269,21 @@ function CDM:AddSettings(dialog, systemFrame)
                 if dialog.orbitTabCallback then dialog.orbitTabCallback() end
             end,
         })
-        if self:GetSetting(systemIndex, "OutOfCombatFade") then
-            table.insert(schema.controls, {
-                type = "checkbox", key = "ShowOnMouseover", label = "Show on Mouseover", default = true,
-                tooltip = "Reveal frame when mousing over it",
-                onChange = function(val)
-                    self:SetSetting(systemIndex, "ShowOnMouseover", val)
-                    local data = VIEWER_MAP[systemIndex]
-                    if data then
-                        local target = data.isTracked and data.anchor or data.viewer
-                        if target then
-                            Orbit.OOCFadeMixin:ApplyOOCFade(target, self, systemIndex, "OutOfCombatFade", val)
-                            Orbit.OOCFadeMixin:RefreshAll()
-                        end
+        table.insert(schema.controls, {
+            type = "checkbox", key = "MouseoverOnly", label = "Mouseover Only", default = false,
+            tooltip = "Only show frame while mousing over it",
+            onChange = function(val)
+                self:SetSetting(systemIndex, "MouseoverOnly", val)
+                local data = VIEWER_MAP[systemIndex]
+                if data then
+                    local target = data.isTracked and data.anchor or data.viewer
+                    if target then
+                        Orbit.OOCFadeMixin:ApplyOOCFade(target, self, systemIndex, "OutOfCombatFade", false)
+                        Orbit.OOCFadeMixin:RefreshAll()
                     end
-                end,
-            })
-        end
+                end
+            end,
+        })
         if systemIndex == Constants.Cooldown.SystemIndex.BuffIcon then
             table.insert(schema.controls, {
                 type = "checkbox", key = "AlwaysShow", label = "Always Show", default = false,

--- a/Orbit/Plugins/CooldownManager/TrackedAbilities.lua
+++ b/Orbit/Plugins/CooldownManager/TrackedAbilities.lua
@@ -387,6 +387,5 @@ function Plugin:ApplyTrackedSettings(anchor)
     OrbitEngine.Frame:RestorePosition(anchor, self, systemIndex)
     self:LoadTrackedItems(anchor, systemIndex)
     Layout:LayoutTrackedIcons(self, anchor, systemIndex, IsDraggingCooldownAbility)
-    local enableHover = self:GetSetting(systemIndex, "ShowOnMouseover") ~= false
-    Orbit.OOCFadeMixin:ApplyOOCFade(anchor, self, systemIndex, "OutOfCombatFade", enableHover)
+    Orbit.OOCFadeMixin:ApplyOOCFade(anchor, self, systemIndex, "OutOfCombatFade", false)
 end

--- a/Orbit/Plugins/CooldownManager/TrackedCharges.lua
+++ b/Orbit/Plugins/CooldownManager/TrackedCharges.lua
@@ -439,8 +439,7 @@ function Plugin:ApplyChargeBarSettings(frame)
     local alpha = isMountedHidden and 0 or ((self:GetSetting(sysIndex, "Opacity") or 100) / 100)
     frame:SetAlpha(alpha)
 
-    local enableHover = self:GetSetting(sysIndex, "ShowOnMouseover") ~= false
-    Orbit.OOCFadeMixin:ApplyOOCFade(frame, self, sysIndex, "OutOfCombatFade", enableHover)
+    Orbit.OOCFadeMixin:ApplyOOCFade(frame, self, sysIndex, "OutOfCombatFade", false)
 end
 
 -- [ UPDATE LOGIC ]---------------------------------------------------------------------------------

--- a/Orbit/Plugins/UnitFrames/Player/PlayerFrame.lua
+++ b/Orbit/Plugins/UnitFrames/Player/PlayerFrame.lua
@@ -29,7 +29,7 @@ local Plugin = Orbit:RegisterPlugin("Player Frame", SYSTEM_ID, {
         HealthTextMode = "percent_short",
         Opacity = 100,
         OutOfCombatFade = false,
-        ShowOnMouseover = true,
+        MouseoverOnly = false,
         AggroIndicatorEnabled = true,
         AggroColor = { r = 1.0, g = 0.0, b = 0.0, a = 1 },
         AggroThickness = 1,
@@ -90,19 +90,17 @@ function Plugin:AddSettings(dialog, systemFrame)
                 dialog.orbitTabCallback()
             end,
         })
-        if self:GetSetting(PLAYER_FRAME_INDEX, "OutOfCombatFade") then
-            table.insert(schema.controls, {
-                type = "checkbox",
-                key = "ShowOnMouseover",
-                label = "Show on Mouseover",
-                default = true,
-                tooltip = "Reveal frame when mousing over it",
-                onChange = function(val)
-                    self:SetSetting(PLAYER_FRAME_INDEX, "ShowOnMouseover", val)
-                    self:ApplySettings()
-                end,
-            })
-        end
+        table.insert(schema.controls, {
+            type = "checkbox",
+            key = "MouseoverOnly",
+            label = "Mouseover Only",
+            default = false,
+            tooltip = "Only show the frame while mousing over it",
+            onChange = function(val)
+                self:SetSetting(PLAYER_FRAME_INDEX, "MouseoverOnly", val)
+                self:ApplySettings()
+            end,
+        })
     end
 
     OrbitEngine.Config:Render(dialog, systemFrame, self, schema)
@@ -434,8 +432,7 @@ function Plugin:ApplySettings(frame)
     self:UpdateRestingIcon(frame)
     frame:UpdatePortrait()
 
-    local enableHover = self:GetSetting(systemIndex, "ShowOnMouseover") ~= false
-    Orbit.OOCFadeMixin:ApplyOOCFade(frame, self, systemIndex, "OutOfCombatFade", enableHover)
+    Orbit.OOCFadeMixin:ApplyOOCFade(frame, self, systemIndex, "OutOfCombatFade", false)
     Orbit.EventBus:Fire("PLAYER_SETTINGS_CHANGED")
 end
 

--- a/Orbit/Plugins/UnitFrames/Player/PlayerPetFrame.lua
+++ b/Orbit/Plugins/UnitFrames/Player/PlayerPetFrame.lua
@@ -17,7 +17,7 @@ local Plugin = Orbit:RegisterPlugin("Pet Frame", SYSTEM_ID, {
         Height = 20,
         Opacity = 100,
         OutOfCombatFade = false,
-        ShowOnMouseover = true,
+        MouseoverOnly = false,
         DisabledComponents = { "HealthText" },
         ComponentPositions = {
             Name = { anchorX = "CENTER", offsetX = 0, anchorY = "CENTER", offsetY = 0, justifyH = "CENTER" },
@@ -59,20 +59,18 @@ function Plugin:AddSettings(dialog, systemFrame)
             self:AddSettings(dialog, systemFrame)
         end,
     })
+    table.insert(schema.controls, {
+        type = "checkbox",
+        key = "MouseoverOnly",
+        label = "Mouseover Only",
+        default = false,
+        tooltip = "Only show the frame while mousing over it",
+        onChange = function(val)
+            self:SetSetting(PET_FRAME_INDEX, "MouseoverOnly", val)
+            self:ApplySettings()
+        end,
+    })
 
-    if self:GetSetting(PET_FRAME_INDEX, "OutOfCombatFade") then
-        table.insert(schema.controls, {
-            type = "checkbox",
-            key = "ShowOnMouseover",
-            label = "Show on Mouseover",
-            default = true,
-            tooltip = "Reveal frame when mousing over it",
-            onChange = function(val)
-                self:SetSetting(PET_FRAME_INDEX, "ShowOnMouseover", val)
-                self:ApplySettings()
-            end,
-        })
-    end
 
     OrbitEngine.Config:Render(dialog, systemFrame, self, schema)
 end
@@ -229,8 +227,7 @@ function Plugin:ApplySettings(frame)
         if frame.ApplyComponentPositions then frame:ApplyComponentPositions() end
     end
 
-    local enableHover = self:GetSetting(systemIndex, "ShowOnMouseover") ~= false
-    Orbit.OOCFadeMixin:ApplyOOCFade(frame, self, systemIndex, "OutOfCombatFade", enableHover)
+    Orbit.OOCFadeMixin:ApplyOOCFade(frame, self, systemIndex, "OutOfCombatFade", false)
     -- Ensure visibility is correctly set (Edit Mode awareness)
     self:UpdateVisibility()
 end

--- a/Orbit/Plugins/UnitFrames/Player/PlayerPower.lua
+++ b/Orbit/Plugins/UnitFrames/Player/PlayerPower.lua
@@ -80,7 +80,7 @@ local Plugin = Orbit:RegisterPlugin("Player Power", SYSTEM_ID, {
         EbonMightColorCurve = { pins = { { position = 0, color = { r = 0.2, g = 0.8, b = 0.4, a = 1 } } } },
         Opacity = 100,
         OutOfCombatFade = false,
-        ShowOnMouseover = true,
+        MouseoverOnly = false,
         SmoothAnimation = true,
         FrequentUpdates = false,
         TickSize = TICK_SIZE_DEFAULT,
@@ -188,19 +188,17 @@ function Plugin:AddSettings(dialog, systemFrame)
                 dialog.orbitTabCallback()
             end,
         })
-        if self:GetSetting(systemIndex, "OutOfCombatFade") then
-            table.insert(schema.controls, {
-                type = "checkbox",
-                key = "ShowOnMouseover",
-                label = "Show on Mouseover",
-                default = true,
-                tooltip = "Reveal frame when mousing over it",
-                onChange = function(val)
-                    self:SetSetting(systemIndex, "ShowOnMouseover", val)
-                    self:ApplySettings()
-                end,
-            })
-        end
+        table.insert(schema.controls, {
+            type = "checkbox",
+            key = "MouseoverOnly",
+            label = "Mouseover Only",
+            default = false,
+            tooltip = "Only show the frame while mousing over it",
+            onChange = function(val)
+                self:SetSetting(systemIndex, "MouseoverOnly", val)
+                self:ApplySettings()
+            end,
+        })
         table.insert(schema.controls, {
             type = "checkbox",
             key = "SmoothAnimation",
@@ -470,8 +468,7 @@ function Plugin:ApplySettings()
     end
 
     -- Apply Out of Combat Fade (with hover detection based on setting)
-    local enableHover = self:GetSetting(systemIndex, "ShowOnMouseover") ~= false
-    Orbit.OOCFadeMixin:ApplyOOCFade(Frame, self, systemIndex, "OutOfCombatFade", enableHover)
+    Orbit.OOCFadeMixin:ApplyOOCFade(Frame, self, systemIndex, "OutOfCombatFade", false)
 
     self:UpdateVisibility()
 end

--- a/Orbit/Plugins/UnitFrames/Player/PlayerResourceSettings.lua
+++ b/Orbit/Plugins/UnitFrames/Player/PlayerResourceSettings.lua
@@ -58,16 +58,14 @@ function Plugin:AddSettings(dialog, systemFrame)
                 if dialog.orbitTabCallback then dialog.orbitTabCallback() end
             end,
         })
-        if self:GetSetting(SYSTEM_INDEX, "OutOfCombatFade") then
-            table.insert(schema.controls, {
-                type = "checkbox", key = "ShowOnMouseover", label = "Show on Mouseover",
-                default = true, tooltip = "Reveal frame when mousing over it",
-                onChange = function(val)
-                    self:SetSetting(SYSTEM_INDEX, "ShowOnMouseover", val)
-                    self:ApplySettings()
-                end,
-            })
-        end
+        table.insert(schema.controls, {
+            type = "checkbox", key = "MouseoverOnly", label = "Mouseover Only",
+            default = false, tooltip = "Only show the frame while mousing over it",
+            onChange = function(val)
+                self:SetSetting(SYSTEM_INDEX, "MouseoverOnly", val)
+                self:ApplySettings()
+            end,
+        })
         table.insert(schema.controls, {
             type = "checkbox", key = "SmoothAnimation", label = "Smooth Animation",
             default = true, tooltip = "Smoothly animate bar value changes",

--- a/Orbit/Plugins/UnitFrames/Player/PlayerResources.lua
+++ b/Orbit/Plugins/UnitFrames/Player/PlayerResources.lua
@@ -84,7 +84,7 @@ local Plugin = Orbit:RegisterPlugin("Player Resources", SYSTEM_ID, {
         TipOfTheSpearColorCurve = { pins = { { position = 0, color = { r = 0.47, g = 0.78, b = 0.22, a = 1 } } } },
         Opacity = 100,
         OutOfCombatFade = false,
-        ShowOnMouseover = true,
+        MouseoverOnly = false,
         SmoothAnimation = true,
         FrequentUpdates = false,
         TickSize = TICK_SIZE_DEFAULT,
@@ -510,8 +510,7 @@ function Plugin:ApplySettings()
     self:UpdatePower()
 
     -- 5. Apply Out of Combat Fade (with hover detection based on setting)
-    local enableHover = self:GetSetting(SYSTEM_INDEX, "ShowOnMouseover") ~= false
-    Orbit.OOCFadeMixin:ApplyOOCFade(Frame, self, SYSTEM_INDEX, "OutOfCombatFade", enableHover)
+    Orbit.OOCFadeMixin:ApplyOOCFade(Frame, self, SYSTEM_INDEX, "OutOfCombatFade", false)
 end
 
 -- [ RESOURCE COLOR (DELEGATE) ]---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a separate `Mouseover Only` visibility option and removes the old nested `Show on Mouseover` setting.

## Change

- adds `Mouseover Only` as its own visibility setting
- keeps `Out of Combat Fade` as a separate setting
- when `Mouseover Only` is enabled, the frame stays hidden until hovered, even in combat
- removes the old `Show on Mouseover` option to avoid overlapping behavior

## Testing

- enabled only `Mouseover Only` and confirmed frames stay hidden until hover
- enabled only `Out of Combat Fade` and confirmed normal fade behavior still works
- checked action bars, unit frames, and cooldown manager frames