### PR TITLE
fix(minimap): compartment flyout, frame strata, canvas dock, QueueStatus edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,10 @@
 ## [@project-version@] - @project-date-iso@
-### New Features
-- Datatext Drawer - Click one of the four corners of the screen to open the datatext drawer. Drag and drop them anywhere on-screen. Drag them back into the drawer to disable. Drag the right hand corner to resize them. Will continue to expand on these and you're welcome to suggest more/improve whats been built.
-
-- Meta Talents - Added a new QoL feature to help you keep track of the most popular talents for each spec. Find it in the Quality of Life tab in `/orbit plugins`.
-    - Select bosses or dungeons to view the most popular talents for that specific encounter, data is fetched and averaged from Warcraft Logs top 100 parses. 
-    - Directly Apply the meta talents to your talent tree with a single click.
-
 ### Bugfixes
-- Static Cooldown Timer Texts
-- Player Buff Item Enhancements now draw a pixel border for item enhancements (weapon oils, etc)
-- Player Buffs/Debuffs swipe now start at low alpha and fill as their duration expires
-- Player Buffs/Debuffs now pulse in and out when expiring
-- Minimap compartment flyout now stays open correctly when used alongside FarmHud
-- FarmHud compatibility - Orbit no longer fights FarmHud's minimap takeover, resource nodes should now display correctly after mount/dismount/shapeshift
+- Minimap compartment no longer shows a question mark icon for the Plumber addon; duplicate entries removed; right-click context menu now appears at the correct position
+- Minimap no longer renders on top of bags, the settings panel, and other UI windows
+- Minimap zoom buttons are now always interactive and not obscured by the click capture overlay
+- The Missions widget in canvas mode now displays a text label instead of a gray square
+- QueueStatus frame is now selectable in edit mode when positioned over the minimap; selecting another frame no longer obscures its selection handle
 
 ## [1.0.0] - 2026-03-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [@project-version@] - @project-date-iso@
+### New Features
+- Datatext Drawer - Click one of the four corners of the screen to open the datatext drawer. Drag and drop them anywhere on-screen. Drag them back into the drawer to disable. Drag the right hand corner to resize them. Will continue to expand on these and you're welcome to suggest more/improve whats been built.
+
+- Meta Talents - Added a new QoL feature to help you keep track of the most popular talents for each spec. Find it in the Quality of Life tab in `/orbit plugins`.
+    - Select bosses or dungeons to view the most popular talents for that specific encounter, data is fetched and averaged from Warcraft Logs top 100 parses. 
+    - Directly Apply the meta talents to your talent tree with a single click.
+
 ### Bugfixes
+- Static Cooldown Timer Texts
+- Player Buff Item Enhancements now draw a pixel border for item enhancements (weapon oils, etc)
+- Player Buffs/Debuffs swipe now start at low alpha and fill as their duration expires
+- Player Buffs/Debuffs now pulse in and out when expiring
+- Minimap compartment flyout now stays open correctly when used alongside FarmHud
+- FarmHud compatibility - Orbit no longer fights FarmHud's minimap takeover, resource nodes should now display correctly after mount/dismount/shapeshift
 - Minimap compartment no longer shows a question mark icon for the Plumber addon; duplicate entries removed; right-click context menu now appears at the correct position
 - Minimap no longer renders on top of bags, the settings panel, and other UI windows
 - Minimap zoom buttons are now always interactive and not obscured by the click capture overlay

--- a/Orbit/Core/CanvasMode/Dock.lua
+++ b/Orbit/Core/CanvasMode/Dock.lua
@@ -12,6 +12,7 @@ local DOCK_OFFSET_X = 14
 local DOCK_OFFSET_Y = 8
 local EXCLUSIVE_PAIRS = { HealthText = "Status", Status = "HealthText" }
 local DOCK_ICON_ALPHA = 0.7
+local DOCK_TEXT_KEYS = { Missions = true } -- keys that have no reliable dock icon; show text label instead
 local DOCK_BG_COLOR = { 0.2, 0.2, 0.2, 0.6 }
 local DOCK_BG_HOVER = { 0.3, 0.5, 0.3, 0.8 }
 local HealerReg = Orbit.HealerAuraRegistry
@@ -102,7 +103,14 @@ function Dialog:AddToDock(key, sourceComponent)
     local isFontString = sourceComponent and sourceComponent.GetFont ~= nil
     local isIconFrame = sourceComponent and sourceComponent.Icon and sourceComponent.Icon.GetTexture
 
-    if isTexture and not isFontString then
+    if DOCK_TEXT_KEYS[key] then
+        icon.visual = icon:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+        icon.visual:SetPoint("CENTER")
+        icon.visual:SetText(DisplayName(key))
+        icon.visual:SetTextColor(0.9, 0.9, 0.9, 1)
+        icon.visual:SetWordWrap(true)
+        icon.visual:SetWidth(C.DOCK_ICON_SIZE - 4)
+    elseif isTexture and not isFontString then
         icon.visual = icon:CreateTexture(nil, "OVERLAY")
         icon.visual:SetPoint("CENTER")
         icon.visual:SetSize(C.DOCK_ICON_SIZE - 4, C.DOCK_ICON_SIZE - 4)
@@ -188,7 +196,7 @@ function Dialog:AddToDock(key, sourceComponent)
         icon.visual = icon:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
         icon.visual:SetPoint("CENTER")
         icon.visual:SetText(DisplayName(key):sub(1, 4))
-        icon.visual:SetTextColor(0.7, 0.7, 0.7, 1)
+        icon.visual:SetTextColor(0.9, 0.9, 0.9, 1)
     end
 
     icon:SetScript("OnEnter", function(self)

--- a/Orbit/Core/EditMode/Frame/Selection.lua
+++ b/Orbit/Core/EditMode/Frame/Selection.lua
@@ -220,6 +220,7 @@ function Selection:Attach(frame, dragCallback, selectionCallback)
 
     local selection = CreateFrame("Frame", nil, frame, "EditModeSystemSelectionTemplate")
     selection:SetAllPoints()
+    selection:SetToplevel(false) -- template has toplevel=true; disable to prevent auto-Raise on Show()
     selection:SetFrameStrata(Orbit.Constants.Strata.Overlay)
     selection:SetFrameLevel(frame:GetFrameLevel() + Orbit.Constants.Levels.EditModeSelection)
     selection.isOrbitSelection = true

--- a/Orbit/Plugins/MenuItems/QueueStatus.lua
+++ b/Orbit/Plugins/MenuItems/QueueStatus.lua
@@ -6,6 +6,7 @@ local OrbitEngine = Orbit.Engine
 local SYSTEM_ID = "Orbit_QueueStatus"
 local DEFAULT_POSITION_X = -250
 local DEFAULT_POSITION_Y = 40
+local EDIT_MODE_FRAME_LEVEL = 50 -- selection = level+100; must beat minimap (~2+100=102)
 
 local Plugin = Orbit:RegisterPlugin("Queue Status", SYSTEM_ID, {
     defaults = {
@@ -53,6 +54,8 @@ end
 function Plugin:OnLoad()
     self.frame = CreateFrame("Frame", "OrbitQueueStatusContainer", UIParent)
     self.frame:SetSize(45, 45)
+    self.frame:SetFrameStrata(Orbit.Constants.Strata.HUD)
+    self.frame:SetFrameLevel(EDIT_MODE_FRAME_LEVEL)
     self.frame:SetClampedToScreen(true)
     self.frame.systemIndex = SYSTEM_ID
     self.frame.editModeName = "Queue Status"

--- a/Orbit/Plugins/Minimap/Minimap.lua
+++ b/Orbit/Plugins/Minimap/Minimap.lua
@@ -126,29 +126,17 @@ function Plugin:OnLoad()
     self.frame.RoundBorder:SetAllPoints(self.frame)
     self.frame.RoundBorder:Hide()
 
-    -- Overlay for canvas components. Uses HIGH strata so our interactive children
-    -- (ZoneText, Clock, zoom buttons, etc.) always take priority over ClickCapture
-    -- (MEDIUM) and any external addon overlay that might sit over the minimap.
+    -- Overlay at MEDIUM strata; interactive children raised above ClickCapture via explicit frame levels.
     self.frame.Overlay = CreateFrame("Frame", nil, self.frame)
     self.frame.Overlay:SetAllPoints()
-    self.frame.Overlay:SetFrameStrata(Orbit.Constants.Strata.Overlay)
+    self.frame.Overlay:SetFrameStrata(Orbit.Constants.Strata.HUD)
     self.frame.Overlay:SetFrameLevel(self.frame:GetFrameLevel() + 10)
     -- MiniMapMailFrameMixin and MiniMapCraftingOrderFrameMixin call self:GetParent():Layout()
     -- after UPDATE_PENDING_MAIL / CRAFTINGORDERS_UPDATED events. Since we reparent those
     -- frames here, we provide a no-op to prevent the error.
     self.frame.Overlay.Layout = function() end
 
-    -- Top-level click-capture button: sits above everything (including third-party addon
-    -- overlays) and intercepts all mouse clicks to dispatch our configured actions.
-    -- SetPropagateMouseClicks(true) ensures clicks also fall through to whatever is
-    -- underneath, so addon overlays (e.g. a "disable minimap" blackout) can still
-    -- receive the same click and dismiss themselves normally.
-    -- ClickCapture: a transparent MEDIUM-strata button that covers the whole minimap
-    -- area. It sits above the minimap render surface and most third-party addon overlays
-    -- (which are typically MEDIUM or LOW), but below our own HIGH-strata Overlay so
-    -- ZoneText, Clock, zoom buttons etc. always take priority.
-    -- SetPropagateMouseClicks(true) ensures the click also falls through to whatever is
-    -- underneath, so addon overlays can still receive and dismiss themselves.
+    -- ClickCapture: transparent MEDIUM button covering the minimap; dispatches configured click actions.
     local clickCapture = CreateFrame("Button", "OrbitMinimapClickCapture", self.frame)
     clickCapture:SetAllPoints()
     clickCapture:SetFrameStrata(Orbit.Constants.Strata.HUD)
@@ -242,6 +230,10 @@ function Plugin:OnLoad()
     self.frame.Coords.Text:SetAllPoints()
     self.frame.Coords.Text:SetJustifyH("RIGHT")
     self.frame.Coords.visual = self.frame.Coords.Text -- canvas override target
+
+    -- Raise interactive children above ClickCapture so OnClick fires before the configured action.
+    self.frame.ZoneText:SetFrameLevel(clickCapture:GetFrameLevel() + 1)
+    self.frame.Clock:SetFrameLevel(clickCapture:GetFrameLevel() + 1)
 
     -- Mouse-wheel zoom: propagate scroll to the Blizzard minimap zoom buttons.
     self.frame:EnableMouseWheel(true)

--- a/Orbit/Plugins/Minimap/MinimapCapture.lua
+++ b/Orbit/Plugins/Minimap/MinimapCapture.lua
@@ -402,7 +402,7 @@ function Plugin:CaptureBlizzardMinimap()
 
     -- Click actions are handled by OrbitMinimapClickCapture (created in OnLoad),
     -- a MEDIUM-strata Button with SetPropagateMouseClicks(true) that covers the whole
-    -- minimap area and sits above most third-party overlays. No per-frame hook needed.
+    -- minimap area, sitting above the Minimap surface but below HIGH-strata plugin frames. No per-frame hook needed.
 
     -- FarmHud integration: register our container and hook show/hide to suspend
     -- FrameGuard protection so FarmHud can reparent the minimap surface freely.

--- a/Orbit/Plugins/Minimap/MinimapCompartment.lua
+++ b/Orbit/Plugins/Minimap/MinimapCompartment.lua
@@ -73,8 +73,10 @@ end
 -- Minimum button width to be considered a real addon button (map pins are typically <20px).
 local MIN_BUTTON_SIZE = 20
 
--- Store reference to the real SetParent method before we override it on collected buttons
-local FrameSetParent = UIParent.SetParent
+-- Store references to raw frame methods before they are overridden on individual collected buttons.
+local FrameSetParent      = UIParent.SetParent
+local FrameClearAllPoints = UIParent.ClearAllPoints
+local FrameSetPoint       = UIParent.SetPoint
 
 -- [ COMPARTMENT BUTTON ]----------------------------------------------------------------------------
 
@@ -86,7 +88,7 @@ function Plugin:CreateCompartmentButton()
     local btn = CreateFrame("Button", "OrbitMinimapCompartmentButton", frame.Overlay or frame)
     btn:SetSize(COMPARTMENT_BUTTON_SIZE, COMPARTMENT_BUTTON_SIZE)
     btn:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -2, 2)
-    btn:SetFrameLevel(frame:GetFrameLevel() + 10)
+    btn:SetFrameLevel(self.frame.ClickCapture:GetFrameLevel() + 2)
     btn.orbitOriginalWidth = COMPARTMENT_BUTTON_SIZE
     btn.orbitOriginalHeight = COMPARTMENT_BUTTON_SIZE
 
@@ -223,15 +225,12 @@ end
 local proxyButtonPool = {}  -- Reusable pool of proxy buttons keyed by original button
 
 local function GetProxyIcon(originalBtn)
-    -- Extract the icon texture from the original button
     local tex = nil
-    -- Try .icon first (LibDBIcon standard field)
     pcall(function()
         if originalBtn.icon and originalBtn.icon.GetTexture then
             tex = originalBtn.icon:GetTexture()
         end
     end)
-    -- Fallback: dataObject.icon
     if not tex then
         pcall(function()
             if originalBtn.dataObject and originalBtn.dataObject.icon then
@@ -239,7 +238,6 @@ local function GetProxyIcon(originalBtn)
             end
         end)
     end
-    -- Fallback: scan regions for a texture with content
     if not tex then
         pcall(function()
             for _, region in ipairs({ originalBtn:GetRegions() }) do
@@ -253,7 +251,6 @@ local function GetProxyIcon(originalBtn)
             end
         end)
     end
-    -- Fallback: GetNormalTexture
     if not tex then
         pcall(function()
             if originalBtn.GetNormalTexture and originalBtn:GetNormalTexture() then
@@ -264,12 +261,12 @@ local function GetProxyIcon(originalBtn)
     return tex
 end
 
-local function GetOrCreateProxyButton(originalBtn, parent, plugin)
+local function GetOrCreateProxyButton(originalBtn, parent)
     if proxyButtonPool[originalBtn] then
         local proxy = proxyButtonPool[originalBtn]
         proxy:SetParent(parent)
         proxy:SetSize(FLYOUT_BUTTON_SIZE, FLYOUT_BUTTON_SIZE)
-        -- Refresh icon in case the addon changed it
+        -- Refresh icon in case the addon updated it
         local tex = GetProxyIcon(originalBtn)
         if tex then proxy._icon:SetTexture(tex) end
         return proxy
@@ -277,9 +274,10 @@ local function GetOrCreateProxyButton(originalBtn, parent, plugin)
 
     local proxy = CreateFrame("Button", nil, parent)
     proxy:SetSize(FLYOUT_BUTTON_SIZE, FLYOUT_BUTTON_SIZE)
+    -- Explicit strata so proxy renders above the flyout backdrop regardless of the original's strata.
+    proxy:SetFrameStrata(parent:GetFrameStrata())
     proxy._originalBtn = originalBtn
 
-    -- Create a clean icon texture
     local icon = proxy:CreateTexture(nil, "ARTWORK")
     icon:SetAllPoints()
     proxy._icon = icon
@@ -290,7 +288,6 @@ local function GetOrCreateProxyButton(originalBtn, parent, plugin)
     else
         icon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark")
     end
-    -- Copy texcoords from original if available
     pcall(function()
         if originalBtn.icon and originalBtn.icon.GetTexCoord then
             icon:SetTexCoord(originalBtn.icon:GetTexCoord())
@@ -300,26 +297,24 @@ local function GetOrCreateProxyButton(originalBtn, parent, plugin)
     icon:SetAlpha(1)
     icon:SetVertexColor(1, 1, 1, 1)
 
-    -- Highlight on hover
     local highlight = proxy:CreateTexture(nil, "HIGHLIGHT")
     highlight:SetAllPoints()
     highlight:SetColorTexture(1, 1, 1, 0.15)
 
-    -- Forward clicks via dataObject.OnClick; AnyUp only to avoid double-fire.
     proxy:RegisterForClicks("AnyUp")
-    proxy:SetScript("OnClick", function(_, button)
-        local btn = originalBtn
+    proxy:SetScript("OnClick", function(self, button)
+        -- Pass proxy (self) not originalBtn so any dropdown/menu anchors to the visible button.
         local b = button or "LeftButton"
+        local btn = originalBtn
         if btn.dataObject and btn.dataObject.OnClick then
-            btn.dataObject.OnClick(btn, b)
+            btn.dataObject.OnClick(self, b)
         elseif btn:GetScript("OnClick") then
-            pcall(function() btn:GetScript("OnClick")(btn, b) end)
+            pcall(function() btn:GetScript("OnClick")(self, b) end)
         else
             pcall(function() btn:Click(b) end)
         end
     end)
 
-    -- Forward tooltip
     proxy:SetScript("OnEnter", function(self)
         if originalBtn.dataObject then
             local dObj = originalBtn.dataObject
@@ -365,15 +360,12 @@ function Plugin:LayoutButtonsInFlyout()
         end
     end
 
-    -- Hide all existing proxy buttons first
+    -- Hide stale proxies from a previous layout pass.
     for _, proxy in pairs(proxyButtonPool) do
         proxy:Hide()
     end
 
     if #visibleEntries == 0 then
-        flyout:SetSize(EMPTY_FLYOUT_W, EMPTY_FLYOUT_H)
-        flyout:ClearAllPoints()
-        flyout:SetPoint("TOPRIGHT", self.frame, "BOTTOMRIGHT", 0, -FLYOUT_GAP)
         if not flyout._emptyText then
             flyout._emptyText = flyout:CreateFontString(nil, "OVERLAY", "GameFontDisableSmall")
             flyout._emptyText:SetPoint("CENTER")
@@ -392,11 +384,11 @@ function Plugin:LayoutButtonsInFlyout()
     local flyoutHeight = (rows * cellSize) + FLYOUT_BUTTON_SPACING + (COMPARTMENT_PADDING * 2)
     flyout:SetSize(flyoutWidth, flyoutHeight)
 
-    -- Create/reuse proxy buttons and position them in a grid
+    -- Create/reuse proxy buttons with explicit strata so rendering is independent of the original button.
     for i, entry in ipairs(visibleEntries) do
         local originalBtn = entry.button
         if originalBtn then
-            local proxy = GetOrCreateProxyButton(originalBtn, flyout, self)
+            local proxy = GetOrCreateProxyButton(originalBtn, flyout)
             proxy:SetFrameLevel(flyout:GetFrameLevel() + 5)
 
             local col = (i - 1) % cols
@@ -457,6 +449,7 @@ function Plugin:CollectAddonButtons()
     -- Track already-collected frame references so we don't double-collect
     local seen = {}
     local seenSignatures = {}
+    local seenNames = {}  -- tracks displayNames; catches duplicates even when icon is nil
 
     -- 1) LibDBIcon registered buttons
     local lib = LibStub and LibStub("LibDBIcon-1.0", true)
@@ -476,6 +469,7 @@ function Plugin:CollectAddonButtons()
                     }
                 end
                 if signature then seenSignatures[signature] = true end
+                seenNames[displayName] = true
                 seen[button] = true
             end
         end
@@ -506,7 +500,14 @@ function Plugin:CollectAddonButtons()
                     -- Skip frames smaller than a real button (map pins are typically <20px)
                     local tooSmall = (child:GetWidth() or 0) < MIN_BUTTON_SIZE
 
-                    if not isBlizzard and not isPin and not tooSmall then
+                    -- Skip protected frames (e.g. SecureActionButton overlays like Plumber's MinimapMouseover)
+                    local isProtected = child:IsProtected()
+
+                    -- Skip hidden buttons — if an addon hides its direct button because it's
+                    -- also registered with LibDBIcon, we don't want both in the compartment.
+                    local isHidden = not child:IsShown()
+
+                    if not isBlizzard and not isPin and not tooSmall and not isProtected and not isHidden then
                         local icon = nil
                         local btnIcon = child.icon or child.Icon
                         if btnIcon and btnIcon.GetTexture then
@@ -516,7 +517,7 @@ function Plugin:CollectAddonButtons()
                         end
                         local displayName = NormalizeCompartmentDisplayName(frameName or tostring(child))
                         local signature = BuildCollectedButtonSignature(displayName, icon)
-                        if not signature or not seenSignatures[signature] then
+                        if (not signature or not seenSignatures[signature]) and not seenNames[displayName] then
                             collected[#collected + 1] = {
                                 name = displayName,
                                 button = child,
@@ -525,6 +526,7 @@ function Plugin:CollectAddonButtons()
                             }
                         end
                         if signature then seenSignatures[signature] = true end
+                        seenNames[displayName] = true
                         seen[child] = true
                     end
                 end
@@ -559,17 +561,18 @@ function Plugin:GrabCollectedButtons()
                 button._orbitOrigScale = button:GetScale()
             end
 
-            -- Reparent to hidden holder via raw SetParent (ours is overridden with doNothing)
-            FrameSetParent(button, holder)
-            button:SetFrameStrata(holder:GetFrameStrata())
-
-            -- Block addons from repositioning their buttons back.
+            -- Block addon repositioning before reparenting so OnParentChanged hooks cannot interfere.
             if not button._orbitMethodsOverridden then
                 button.ClearAllPoints = doNothing
                 button.SetPoint = doNothing
                 button.SetParent = doNothing
                 button._orbitMethodsOverridden = true
             end
+
+            -- Reparent to hidden holder via raw SetParent (bypasses the doNothing override above)
+            FrameSetParent(button, holder)
+            button:SetFrameStrata(holder:GetFrameStrata())
+            button:Hide()
 
             -- Disable drag scripts
             button:SetScript("OnDragStart", nil)

--- a/Orbit/Plugins/Minimap/MinimapComponents.lua
+++ b/Orbit/Plugins/Minimap/MinimapComponents.lua
@@ -229,6 +229,7 @@ function Plugin:CreateZoomButtons()
     container:SetSize(ZOOM_BUTTON_W, ZOOM_BUTTON_IN_H + 2 + ZOOM_BUTTON_OUT_H)
     container:SetPoint("RIGHT", self.frame, "RIGHT", -2, 0)
     self.frame.ZoomContainer = container
+    container:SetFrameLevel(self.frame.ClickCapture:GetFrameLevel() + 1)
 
     -- Hidden icon for canvas mode dock preview (sized to match ZoomIn button)
     container.Icon = container:CreateTexture(nil, "ARTWORK")


### PR DESCRIPTION
Fixes several minimap and related issues:

**Compartment flyout**
- Plumber now shows correct expansion icon (was showing question mark)
- Plumber no longer appears twice in the flyout
- Right-clicking an addon button now anchors the context menu at the visible flyout position

**Frame strata**
- Minimap overlay lowered to MEDIUM — no longer renders over bags, character sheet, map, or config panels
- Minimap zoom buttons are now always interactive; the click capture overlay no longer sits above them

**Canvas mode**
- Missions component now shows a text label in the disabled dock instead of a gray square

**Edit mode**
- QueueStatus selection handle is now accessible when placed over the minimap; selecting other frames no longer re-obscures it (selection frames now use stable frame levels instead of auto-raise)