### PR TITLE
fix wrongly displayed Unit Frame Tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .vscode/
+.idea
 
 # Libraries fetched by BigWigs packager at build time.
 # Set as externals in .pkgmeta and ignored here.

--- a/Orbit/Core/UnitDisplay/UnitButton.lua
+++ b/Orbit/Core/UnitDisplay/UnitButton.lua
@@ -189,17 +189,26 @@ function UnitButton:Create(parent, unit, name, skipEventRegistration)
     f:SetScript("OnEvent", f.OnEvent)
     f:OnLoad(skipEventRegistration)
 
+    -- Helper function based on the Blizzard UnitFrame_UpdateTooltip method
+    -- without the Right-Click instruction line
+    local function OrbitUnitFrame_UpdateTooltip(frame)
+        GameTooltip_SetDefaultAnchor(GameTooltip, frame)
+        if GameTooltip:SetUnit(frame.unit) then
+            GameTooltip:Show()
+
+            frame.UpdateTooltip = OrbitUnitFrame_UpdateTooltip
+        else
+            frame.UpdateTooltip = nil
+        end
+    end
+
     f:SetScript("OnEnter", function(self)
         self:SetMouseOver(true)
-        if self.unit and UnitExists(self.unit) then
-            GameTooltip_SetDefaultAnchor(GameTooltip, self)
-            GameTooltip:SetUnit(self.unit)
-            GameTooltip:Show()
-        end
+        OrbitUnitFrame_UpdateTooltip(self)
     end)
     f:SetScript("OnLeave", function(self)
         self:SetMouseOver(false)
-        GameTooltip:Hide()
+        GameTooltip:FadeOut()
     end)
 
     f:HookScript("OnSizeChanged", function(self)


### PR DESCRIPTION
Fixing the issue with non updating UnitFrame Tooltips.

This applies to Player, Target, Focus and Raid Frames

Before:
<img width="375" height="273" alt="Screenshot 2026-04-22 132322" src="https://github.com/user-attachments/assets/ab3ba290-5656-4165-ae6e-1663b79e6284" />

After - This applies Data from my AddOn Better Tooltip
<img width="381" height="243" alt="image" src="https://github.com/user-attachments/assets/76f2be4f-1101-4852-9fb4-c4ae06d760d9" />
